### PR TITLE
Fix typo + residual Markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,11 +532,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </ul>
 </div>
 <div class="paragraph">
-<p><em>Funcatron let&#8217;s you deploy serverless on any cloud provider or in your
+<p><em>Funcatron lets you deploy serverless on any cloud provider or in your
 private cloud. Focus on the functions, avoid vendor lock-in.</em></p>
 </div>
 <div class="paragraph">
-<p>This document sets out the goals for the [Funcatron](<a href="http://funcatron.org" class="bare">http://funcatron.org</a>) project.</p>
+<p>This document sets out the goals for the <a href="http://funcatron.org">Funcatron</a> project.</p>
 </div>
 <div class="sect2">
 <h3 id="_what_s_funcatron">What&#8217;s Funcatron</h3>
@@ -853,7 +853,7 @@ how to make a contribution.</p>
 </div>
 <div class="paragraph">
 <p>Support is available from the project&#8217;s founder,
-[David Pollak](mailto:feeder.of.the.bears@gmail.com).</p>
+<a href="mailto:feeder.of.the.bears@gmail.com">David Pollak</a>.</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Fixes a typo and a couple of errors in conversion from Markdown to HTML.